### PR TITLE
4.x kafka support

### DIFF
--- a/docs/en/architecture.mdx
+++ b/docs/en/architecture.mdx
@@ -10,18 +10,6 @@ i18n:
 
 Alauda Streaming Service for Kafka leverages Kafka's distributed architecture to provide a proven high-availability solution, meeting enterprise requirements for high-throughput, reliable, and elastically scalable message queuing systems.
 
-## ZooKeeper Coordination Mode
-
-The ZooKeeper coordination mode is the traditional distributed coordination implementation for Kafka, utilizing a ZooKeeper cluster to manage Kafka cluster metadata, Broker registration, and controller election, among other core functionalities. This mode has the following characteristics:
-
-- **Mature and Stable**: Verified in large-scale production environments, it has extremely high reliability.
-- **Separation of Concerns**: ZooKeeper focuses on cluster coordination, while Kafka brokers concentrate on message processing.
-- **Automatic Failover**: Controller automatic election achieved via ZooKeeper's watcher mechanism.
-- **Metadata Management**: Stores key metadata such as topic partition information and consumer offsets.
-- **Expansion Dependency**: Requires additional maintenance of a ZooKeeper cluster, introducing operational complexity.
-
-![kafka zk arch](./assets/zk_arch.png)
-
 ## KRaft Mode
 
 KRaft mode is Kafka's next-generation metadata management system, which replaces ZooKeeper with Kafka's native Raft-based consensus protocol. This mode offers the following characteristics:

--- a/docs/en/functions/10-create-instance.mdx
+++ b/docs/en/functions/10-create-instance.mdx
@@ -170,8 +170,8 @@ After creating the instance, you can check the status of the instance using the 
 ```bash
 $ kubectl get rdskafka -n <namespace> -o=custom-columns=NAME:.metadata.name,VERSION:.spec.version,STATUS:.status.phase,MESSAGE:.status.reason,CreationTimestamp:.metadata.creationTimestamp
 NAME         VERSION   STATUS   MESSAGE                                   CreationTimestamp
-my-cluster   3.8       Active   <none>                                    2025-03-06T08:46:57Z
-test38       3.8       Failed   Pod is unschedulable or is not starting   2025-03-06T08:46:36Z
+my-cluster   4.1       Active   <none>                                    2025-03-06T08:46:57Z
+test41       4.1       Failed   Pod is unschedulable or is not starting   2025-03-06T08:46:36Z
 ```
 
 The meanings of the output table fields are as follows:
@@ -179,7 +179,7 @@ The meanings of the output table fields are as follows:
 | Field                | Description                                                                                                                                                                                                   |
 | :---------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | NAME              | Instance Name                                                                                                                                                                                                 |
-| VERSION           | Currently only supports these 4 versions: `2.5.0`, `2.7.0`, `2.8.2`, `3.8`                                                                                                                                                         |
+| VERSION           | Currently only supports version: `4.1`                                                                                                                                                         |
 | STATUS            | The current status of the instance, which may have the following statuses: <ul><li>`Creating`: The instance is being created</li><li>`Updating`: The instance is being updated</li><li>`Failed`: The instance has encountered an unrecoverable error</li><li>`Paused`: The instance has been manually paused</li><li>`Restarting`: The instance is restarting</li><li>`Active`: The instance is ready for use</li></ul> |
 | MESSAGE           | The reason for the instance's current status                                                                                                                                                                                          |
 | CreationTimestamp | The timestamp when the instance was created                                                                                                                                                                                              |
@@ -332,7 +332,7 @@ The meanings of the output table fields are as follows:
 
     5. Complete other configurations.
 
-    6. Switch to the YAML editing page and change the values of `spec.replicas` and `spec.zookeeper.replicas` to 1
+    6. Switch to the YAML editing page and change the values of `spec.replicas` and `spec.controller.replicas` to 1
 
     7. Click on **Create**.
 

--- a/docs/en/functions/10-create-instance.mdx
+++ b/docs/en/functions/10-create-instance.mdx
@@ -47,7 +47,7 @@ You can create a Kafka instance to build a high-throughput, low-latency real-tim
             requests:
               cpu: 200m
               memory: 128Mi
-      version: 3.8
+      version: 4.1
       replicas: 3
       config:
         auto.create.topics.enable: "false"
@@ -228,7 +228,7 @@ The meanings of the output table fields are as follows:
             requests:
               cpu: 200m
               memory: 128Mi
-      version: 3.8
+      version: 4.1
       replicas: 1
       config:
         auto.create.topics.enable: "false"
@@ -269,7 +269,10 @@ The meanings of the output table fields are as follows:
           external:
             type: nodeport
             tls: false
-      zookeeper:
+      mode: KRaft
+      controller:
+        roles:
+          - controller
         # Currently the same as Kafka broker
         replicas: 1
         resources:

--- a/docs/en/functions/40-parameter.mdx
+++ b/docs/en/functions/40-parameter.mdx
@@ -27,11 +27,7 @@ When creating a Kafka instance, the system parameter template is used by default
      `security.`
      `servers,node.id`
      `ssl.`
-     `super.user`
-     `zookeeper.clientCnxnSocket`
-     `zookeeper.connect`
-     `zookeeper.set.acl`
-     `zookeeper.ssl`).
+     `super.user`).
 </Directive>
 
 ## Procedure
@@ -111,7 +107,5 @@ When creating a Kafka instance, the system parameter template is used by default
 | transaction.state.log.segment.bytes | int | The transaction topic segment bytes should be kept relatively small in order to facilitate faster log compaction and cache loads | 104857600 | \[1,...\] |
 | transactional.id.expiration.ms | int | The time in ms that the transaction coordinator will wait without receiving any transaction status updates for the current transaction before expiring its transactional id. This setting also influences producer id expiration - producer ids are expired once this time has elapsed after the last write with the given producer id. Note that producer ids may expire sooner if the last write from the producer id is deleted due to the topic's retention settings. | 604800000 | \[1,...\] |
 | unclean.leader.election.enable | boolean | Indicates whether to enable replicas not in the ISR set to be elected as leader as a last resort, even though doing so may result in data loss | false |     |
-| zookeeper.max.in.flight.requests | int | The maximum number of unacknowledged requests the client will send to Zookeeper before blocking. | 10  | \[1,...\] |
-| zookeeper.session.timeout.ms | int | Zookeeper session timeout | 18000 |     |
 
 For more parameter support, go to the [Kafka website](https://kafka.apache.org/documentation/#configuration).

--- a/docs/en/how_to/40-config.mdx
+++ b/docs/en/how_to/40-config.mdx
@@ -8,9 +8,9 @@ sourceSHA: d50f1af4dae9e3127d3a036d3427c7ca259fe6d7cc95109db2403dea8bd8ba9f
 To ensure secure communication, please complete the configuration related to encrypted transmission on the Kafka client.
 
 
-:::info Notes
+<Directive type="info" title="Notes">
 The following operations should be performed on the **control node** within the cluster.
-:::
+</Directive>
 
 ## Required File Preview
 
@@ -97,9 +97,9 @@ ssl.keystore.location=/home/kafka/user.p12
 ssl.keystore.password={user certificate password}
 EOF
 ```
-:::tip
+<Directive type="tip">
 To enable external access, include ssl.endpoint.identification.algorithm= in the configuration file.
-:::
+</Directive>
 
 ## IV. Copy Files to Client
 

--- a/docs/en/how_to/50-migrate-to-kraft.mdx
+++ b/docs/en/how_to/50-migrate-to-kraft.mdx
@@ -6,6 +6,12 @@ weight: 50
 
 Starting from Kafka 4.0, ZooKeeper mode will no longer be supported. The operator will also remove support for ZooKeeper mode in future versions. It is recommended to migrate your Kafka instances to KRaft mode as soon as possible.
 
+:::warning Important Version Note
+- **v4.2.x operator only supports KRaft mode**: ZooKeeper mode has been completely removed in v4.2.x.
+- **Migration must be completed before upgrading to v4.2.x**: If you plan to upgrade to Alauda Streaming Service for Kafka v4.2.x, you must migrate all your instances to KRaft mode using the v4.1.x operator first.
+- **v4.2.x cannot perform migration**: The v4.2.x operator does not support ZooKeeper mode and cannot handle migration from ZooKeeper to KRaft. You must complete migration while still on v4.1.x.
+:::
+
  <Directive type="warning" title="Migration Considerations">
  - **Service Interruption**: The migration process may cause temporary service interruptions.
  - **Connection Changes**: After migration, pod names and service (svc) names will change, which may cause connection addresses to shift. It is critical to update the access addresses of your instances promptly post-migration.If you connect to the Kafka instance using the bootstrap or external-bootstrap services, the access address will remain unchanged and no updates are needed.
@@ -17,16 +23,25 @@ Starting from Kafka 4.0, ZooKeeper mode will no longer be supported. The operato
 - Kafka version must be **3.8** or higher
 - Notify consumers/producers about potential temporary disruptions
 - Ensure the Kafka cluster is healthy and fully operational
+- Verify the current mode of your Kafka instances:
+  ```bash
+  kubectl get rdskafka -A -o custom-columns="NAME:.metadata.name,NAMESPACE:.metadata.namespace,MODE:.spec.mode,PHASE:.status.phase"
+  ```
+  This will help you identify which instances are still in ZooKeeper mode and need migration.
 
 ## Migration Steps
 
 <Tabs>
   <Tab label="CLI">
-1. Patch the Kafka instance to switch to KRaft mode:
+1. First, check the current mode of your Kafka instances:
+    ```bash
+    kubectl get rdskafka -A -o custom-columns="NAME:.metadata.name,NAMESPACE:.metadata.namespace,MODE:.spec.mode,PHASE:.status.phase"
+    ```
+2. Patch the Kafka instance to switch to KRaft mode:
     ```bash
     kubectl patch rdsKafka <name> -n <namespace> --type=merge -p '{"spec":{"mode":"KRaft"}}'
     ```
-2. Monitor the migration status:
+3. Monitor the migration status:
     ```bash
     kubectl get rdsKafka <name> -n <namespace> -o jsonpath='{.status.phase}'
     ```

--- a/docs/en/how_to/50-migrate-to-kraft.mdx
+++ b/docs/en/how_to/50-migrate-to-kraft.mdx
@@ -6,11 +6,11 @@ weight: 50
 
 Starting from Kafka 4.0, ZooKeeper mode will no longer be supported. The operator will also remove support for ZooKeeper mode in future versions. It is recommended to migrate your Kafka instances to KRaft mode as soon as possible.
 
-:::warning Important Version Note
+<Directive type="warning" title="Important Version Note">
 - **v4.2.x operator only supports KRaft mode**: ZooKeeper mode has been completely removed in v4.2.x.
 - **Migration must be completed before upgrading to v4.2.x**: If you plan to upgrade to Alauda Streaming Service for Kafka v4.2.x, you must migrate all your instances to KRaft mode using the v4.1.x operator first.
 - **v4.2.x cannot perform migration**: The v4.2.x operator does not support ZooKeeper mode and cannot handle migration from ZooKeeper to KRaft. You must complete migration while still on v4.1.x.
-:::
+</Directive>
 
  <Directive type="warning" title="Migration Considerations">
  - **Service Interruption**: The migration process may cause temporary service interruptions.

--- a/docs/en/how_to/50-migrate-to-kraft.mdx
+++ b/docs/en/how_to/50-migrate-to-kraft.mdx
@@ -6,7 +6,7 @@ weight: 50
 
 Starting from Kafka 4.0, ZooKeeper mode will no longer be supported. The operator will also remove support for ZooKeeper mode in future versions. It is recommended to migrate your Kafka instances to KRaft mode as soon as possible.
 
-<Directive type="warning" title="Important Version Note">
+<Directive type="note" title="Important Version Note">
 - **v4.2.x operator only supports KRaft mode**: ZooKeeper mode has been completely removed in v4.2.x.
 - **Migration must be completed before upgrading to v4.2.x**: If you plan to upgrade to Alauda Streaming Service for Kafka v4.2.x, you must migrate all your instances to KRaft mode using the v4.1.x operator first.
 - **v4.2.x cannot perform migration**: The v4.2.x operator does not support ZooKeeper mode and cannot handle migration from ZooKeeper to KRaft. You must complete migration while still on v4.1.x.

--- a/docs/en/how_to/50-migrate-to-kraft.mdx
+++ b/docs/en/how_to/50-migrate-to-kraft.mdx
@@ -6,7 +6,7 @@ weight: 50
 
 Starting from Kafka 4.0, ZooKeeper mode will no longer be supported. The operator will also remove support for ZooKeeper mode in future versions. It is recommended to migrate your Kafka instances to KRaft mode as soon as possible.
 
-<Directive type="note" title="Important Version Note">
+<Directive type="info" title="Important Version Note">
 - **v4.2.x operator only supports KRaft mode**: ZooKeeper mode has been completely removed in v4.2.x.
 - **Migration must be completed before upgrading to v4.2.x**: If you plan to upgrade to Alauda Streaming Service for Kafka v4.2.x, you must migrate all your instances to KRaft mode using the v4.1.x operator first.
 - **v4.2.x cannot perform migration**: The v4.2.x operator does not support ZooKeeper mode and cannot handle migration from ZooKeeper to KRaft. You must complete migration while still on v4.1.x.

--- a/docs/en/installation.mdx
+++ b/docs/en/installation.mdx
@@ -11,9 +11,9 @@ title: Install
 
 ## Installing Alauda Container Platform Data Services Essentials
 
-::: tip Optional Deployment
+<Directive type="tip" title="Optional Deployment">
 The plugin is a fundamental component of Alauda Application Services graphical interface; it can be omitted if web console are not required.
-:::
+</Directive>
 
 ### Prerequisites
 
@@ -32,9 +32,9 @@ The plugin is a fundamental component of Alauda Application Services graphical i
 
 ## Installing Alauda Container Platform Data Services RDS Framework
 
-::: tip Optional Deployment
+<Directive type="tip" title="Optional Deployment">
 The plugin is a fundamental component of Alauda Application Services graphical interface; it can be omitted if web console are not required.
-:::
+</Directive>
 
 ### Prerequisites
 
@@ -94,9 +94,9 @@ The plugin is a fundamental component of Alauda Application Services graphical i
 
 ## Installing the Alauda build of Kafka 2 Plugin
 
-:::tip Optional Deployment
+<Directive type="tip" title="Optional Deployment">
 This plugin manages Kafka instances for versions `2.x`; it can be omitted if `2.x` version instances are not required.
-:::
+</Directive>
 
 ### Prerequisites
 

--- a/docs/en/installation.mdx
+++ b/docs/en/installation.mdx
@@ -64,10 +64,6 @@ The plugin is a fundamental component of Alauda Application Services graphical i
 
 ## Installing the Alauda Streaming Service for Kafka Plugin
 
-:::tip Optional Deployment
-This plugin manages Kafka instances for versions `3.x`; if you need to manage `2.x` instances, the Alauda build of Kafka 2 plugin must be installed additionally.
-:::
-
 ### Prerequisites
 
 1. Download the plugin installation package that matches your platform.

--- a/docs/en/intro.mdx
+++ b/docs/en/intro.mdx
@@ -10,12 +10,11 @@ i18n:
 
 ## Kafka Introduction
 
-**Kafka** is a distributed stream processing platform known for its high throughput, low latency, scalability, and fault tolerance. As a distributed message queue, Kafka efficiently transports and stores large volumes of data between different systems. It supports various data formats and can handle real-time data streams, widely used in log collection, event-driven architectures, real-time analytics, data integration, and many other fields. Kafka employs a distributed architecture with core components including Producers, Consumers, Topics, and Brokers, and ensures data reliability and high availability through partitioning and replication mechanisms. 
+**Kafka** is a distributed stream processing platform known for its high throughput, low latency, scalability, and fault tolerance. As a distributed message queue, Kafka efficiently transports and stores large volumes of data between different systems. It supports various data formats and can handle real-time data streams, widely used in log collection, event-driven architectures, real-time analytics, data integration, and many other fields. Kafka employs a distributed architecture with core components including Producers, Consumers, Topics, and Brokers, and ensures data reliability and high availability through partitioning and replication mechanisms.
 
 In terms of deployment modes, it supports:
 
-- **ZooKeeper (ZK) mode**: The traditional mode, relying on ZooKeeper to manage cluster metadata.
-- **KRaft mode**: The next-generation mode that removes ZooKeeper dependency by using Kafka's own Raft consensus protocol for metadata management. Key features include:
+- **KRaft mode**: The next-generation mode that removes ZooKeeper dependency by using Kafka's own Raft consensus protocol for metadata management.
 
 ## Alauda Streaming Service for Kafka Introduction
 
@@ -23,17 +22,14 @@ In terms of deployment modes, it supports:
 
 ### Key Features
 
-1. **ZooKeeper Mode Support**
-   ZooKeeper maintains metadata information for the Kafka cluster, including node status, topic partition allocation, etc., ensuring stable operation and coordination of the cluster. Especially suitable for various sizes of production environments.
-
-2. **KRaft Mode Support**
+1. **KRaft Mode Support**
    The next-generation mode that eliminates ZooKeeper dependency, using Kafka's built-in Raft protocol for metadata management. Provides:
    - Simplified architecture with fewer components to manage
    - Improved scalability for large clusters
    - Faster controller failover
    - Support for both combined and dedicated controller roles
 
-3. **Access Control and Security**
+2. **Access Control and Security**
    - Supports TLS encryption to ensure data security during transmission, preventing data theft or tampering.
    - Provides a comprehensive user authentication and authorization mechanism to strictly control access to the Kafka cluster for different users or applications, ensuring secure access to sensitive data.
 

--- a/docs/en/lifecycle_policy.mdx
+++ b/docs/en/lifecycle_policy.mdx
@@ -10,7 +10,7 @@ Below is the lifecycle schedule for released versions of the Alauda Streaming Se
 
 | Alauda Streaming Service for Kafka Version | Release Date | End of Support                                        |
 |:------------------------------------------:|:------------:|:-----------------------------------------------------:|
-| v4.2.x                                     | 2025-12-15   | Supported until 1 month post-release of the next version|
+| v4.2.x                                     | 2026-02-06   | Supported until 1 month post-release of the next version|
 | v4.1.x                                     | 2025-08-18   | Supported until 1 month post-release of v4.2.x plus 1 month|
 
 

--- a/docs/en/lifecycle_policy.mdx
+++ b/docs/en/lifecycle_policy.mdx
@@ -10,7 +10,8 @@ Below is the lifecycle schedule for released versions of the Alauda Streaming Se
 
 | Alauda Streaming Service for Kafka Version | Release Date | End of Support                                        |
 |:------------------------------------------:|:------------:|:-----------------------------------------------------:|
-| v4.1.x                                     | 2025-08-18   | Supported until 1 month post-release of the next version|
+| v4.2.x                                     | 2025-12-15   | Supported until 1 month post-release of the next version|
+| v4.1.x                                     | 2025-08-18   | Supported until 1 month post-release of v4.2.x plus 1 month|
 
 
 ## Release Policy

--- a/docs/en/release_notes.mdx
+++ b/docs/en/release_notes.mdx
@@ -8,6 +8,23 @@ i18n:
 
 # Release Notes
 
+## v4.2.0
+
+### New and Optimized Features
+
+#### Community Kafka 4.1.1 Support
+- Added support for the community Kafka version 4.1.1.
+- All new instances created with v4.2.x will use Kafka 4.1.1 by default.
+
+#### ZooKeeper Mode Removal
+- **ZooKeeper mode has been completely removed**: v4.2.x only supports KRaft mode.
+- This aligns with the upstream Kafka community direction where ZooKeeper mode is deprecated.
+- **Important**: All existing instances must be migrated to KRaft mode before upgrading to v4.2.x. Use the v4.1.x operator for migration.
+
+#### Kubernetes Security Hardening
+- Enhanced security configurations for Kubernetes deployments.
+- Added security context constraints for better pod isolation.
+
 ## v4.1.0
 
 ### New and Optimized Features

--- a/docs/en/upgrade.mdx
+++ b/docs/en/upgrade.mdx
@@ -7,10 +7,10 @@ i18n:
 
 # Upgrade
 
-:::note
+<Directive type="note">
 
 This document provides the upgrade path principles and supported version compatibility for Alauda Streaming Service for Kafka.
-:::
+</Directive>
 
 ## Compatibility Matrix
 

--- a/docs/en/upgrade.mdx
+++ b/docs/en/upgrade.mdx
@@ -22,10 +22,10 @@ The table below lists supported versions of the Alauda Streaming Service for Kaf
 | v4.1.x               | 3.8.1, 2.8.2 (with plugin)     | ZooKeeper & KRaft   | 1.25+               |
 | v4.0.x               | 3.8.1, 2.8.2 (with plugin)     | ZooKeeper & KRaft   | 1.25+               |
 
-:::tip Important Notes
+<Directive type="tip" title="Important Notes">
 - **v4.2.x only supports KRaft mode**: ZooKeeper mode has been completely removed. All instances must be running in KRaft mode before upgrading to v4.2.x.
 - **Migration requirement**: If you have instances in ZooKeeper mode, you must migrate them to KRaft mode using the v4.1.x operator before upgrading to v4.2.x.
-:::
+</Directive>
 
 ## Prerequisites
 

--- a/docs/en/upgrade.mdx
+++ b/docs/en/upgrade.mdx
@@ -16,13 +16,15 @@ This document provides the upgrade path principles and supported version compati
 
 The table below lists supported versions of the Alauda Streaming Service for Kafka and its key components:
 
-| Alauda Kafka Version |  Kafka Versions                | Kubernetes Versions |
-|:--------------------:|:------------------------------:|:-------------------:|
-| v4.1.x               | 3.8.1, 2.8.2 (with plugin)     | 1.25+               |
-| v4.0.x               | 3.8.1, 2.8.2 (with plugin)     | 1.25+               |
+| Alauda Kafka Version |  Kafka Versions                | Mode Support        | Kubernetes Versions |
+|:--------------------:|:------------------------------:|:-------------------:|:-------------------:|
+| v4.2.x               | 4.1.1                          | KRaft               | 1.27+               |
+| v4.1.x               | 3.8.1, 2.8.2 (with plugin)     | ZooKeeper & KRaft   | 1.25+               |
+| v4.0.x               | 3.8.1, 2.8.2 (with plugin)     | ZooKeeper & KRaft   | 1.25+               |
 
-:::tip Optional Deployment
-For versions that support Kafka 2 (marked as *with plugin* in the table), you can manage Kafka 2.x instances by installing the Alauda build of the Kafka 2 plugin.
+:::tip Important Notes
+- **v4.2.x only supports KRaft mode**: ZooKeeper mode has been completely removed. All instances must be running in KRaft mode before upgrading to v4.2.x.
+- **Migration requirement**: If you have instances in ZooKeeper mode, you must migrate them to KRaft mode using the v4.1.x operator before upgrading to v4.2.x.
 :::
 
 ## Prerequisites
@@ -32,6 +34,15 @@ Before initiating an upgrade, please ensure the following:
 1. **Version Compatibility**: Your current version falls within a supported upgrade path.
 2. **Component Health**: Kafka instances are in a `Ready` state.
 3. **Resource Availability**: The cluster has sufficient resources to support the upgrade process.
+4. **KRaft Mode Verification**:  Verify that all rdskafka instances have `spec.mode` set to `KRaft`.
+   - You can use the following command to check the mode of all Kafka instances:
+     ```bash
+     kubectl get rdskafka -A -o custom-columns="NAME:.metadata.name,NAMESPACE:.metadata.namespace,MODE:.spec.mode,PHASE:.status.phase"
+     ```
+   - If any instance is **not in KRaft mode** , you **must** migrate it to KRaft mode using the v4.1.x operator before upgrading to v4.2.x.
+   - The v4.2.x operator does not support ZooKeeper mode and will not handle migration from ZooKeeper to KRaft.
+   - A migration plan from ZooKeeper mode to Kraft mode is available ([migrate to kraft](../how_to/50-migrate-to-kraft.mdx)).
+
 
 For version-specific changes, new features, and deprecations, see the 📝 **[Release Notes](./release_notes.mdx)**.
 
@@ -47,7 +58,17 @@ For version-specific changes, new features, and deprecations, see the 📝 **[Re
 
 ### Kafka Version Alignment
 - **Description**: Ensure Kafka version upgrades follow the operator's compatibility matrix.
-- **Example**: Alauda Streaming Service for Kafka `4.1.0` supports Kafka `3.8.1` or Kafka `2.8.2` (with plugin).
+- **Example**:
+  - Alauda Streaming Service for Kafka `4.1.x` supports Kafka `3.8.1` or Kafka `2.8.2` (with plugin).
+
+### Special Note for v4.2.x Upgrade
+- **KRaft Mode Requirement**: All instances must be in KRaft mode before upgrading to v4.2.x.
+- **Migration Path**: If you have instances in ZooKeeper mode:
+  1. Stay on v4.1.x operator
+  2. Migrate all instances to KRaft mode using the migration procedure
+  3. Verify all instances are running successfully in KRaft mode
+  4. Upgrade operator to v4.2.x
+- **No Rollback to ZooKeeper**: Once migrated to KRaft mode, rolling back to ZooKeeper mode is not supported.
 
 ## Upgrade strategy
 

--- a/docs/en/upgrade.mdx
+++ b/docs/en/upgrade.mdx
@@ -25,6 +25,7 @@ The table below lists supported versions of the Alauda Streaming Service for Kaf
 <Directive type="tip" title="Important Notes">
 - **v4.2.x only supports KRaft mode**: ZooKeeper mode has been completely removed. All instances must be running in KRaft mode before upgrading to v4.2.x.
 - **Migration requirement**: If you have instances in ZooKeeper mode, you must migrate them to KRaft mode using the v4.1.x operator before upgrading to v4.2.x.
+- **Irreversible**: Once migrated to KRaft mode, rolling back to ZooKeeper mode is not supported.
 </Directive>
 
 ## Prerequisites


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * v4.2.x removes ZooKeeper mode—KRaft is the only supported coordination mode; added prominent warning about migration prerequisites and irreversibility.
  * Added v4.2.0 release notes and lifecycle entry; set Kafka 4.1.1/4.1 as default for new instances.
  * Expanded migration and upgrade guidance with an explicit pre-check step and reordered migration steps.
  * Removed ZooKeeper-related parameters/examples and standardized tip/note markup across docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->