### PR TITLE
add kafka bridge connect docs

### DIFF
--- a/docs/en/how_to/35-kafka-connect.mdx
+++ b/docs/en/how_to/35-kafka-connect.mdx
@@ -302,13 +302,39 @@ spec:
             key: password
 ```
 
-<Directive type="note" title="Deprecation Notice">
-The `externalConfiguration` property is deprecated in newer Strimzi versions. Use `spec.template.connectContainer.env` with `valueFrom.secretKeyRef` or `valueFrom.configMapKeyRef` for new deployments. Existing `externalConfiguration` setups continue to work but should be migrated.
+<Directive type="note" title="Migration Guidance">
+In newer Strimzi versions, `spec.externalConfiguration` is being phased out in favor of standard pod template fields. Existing `externalConfiguration` setups continue to work, but new deployments should use the following alternatives:
+
+- For environment variables sourced from a Secret or ConfigMap, use `spec.template.connectContainer.env` with `valueFrom.secretKeyRef` or `valueFrom.configMapKeyRef`.
+- For file-based secrets used with `${file:...}` references, mount the Secret or ConfigMap through `spec.template.pod.volumes` and `spec.template.connectContainer.volumeMounts`. Additional volumes are mounted under `/mnt`, so connector configuration must reference files through that path.
+
+The following example mounts a Secret at `/mnt/connector-secrets` so that connectors can read credentials from a properties file:
+
+```yaml
+spec:
+  config:
+    config.providers: file
+    config.providers.file.class: org.apache.kafka.common.config.provider.FileConfigProvider
+  template:
+    pod:
+      volumes:
+        - name: connector-secrets
+          secret:
+            secretName: my-connector-secrets
+    connectContainer:
+      volumeMounts:
+        - name: connector-secrets
+          mountPath: /mnt/connector-secrets
+```
+
+Connectors then reference values using `${file:/mnt/connector-secrets/<file>:<key>}`.
 </Directive>
 
 ## Configure Logging
 
 Use `spec.logging` to configure the log levels for Kafka Connect workers. You can use inline logging or reference an external ConfigMap.
+
+Kafka Connect uses log4j2. Both inline and external configuration follow the log4j2 property syntax.
 
 Inline logging:
 
@@ -317,10 +343,14 @@ spec:
   logging:
     type: inline
     loggers:
-      log4j.rootLogger: INFO
-      log4j.logger.org.apache.kafka.connect: DEBUG
-      log4j.logger.org.apache.kafka.connect.runtime: WARN
+      rootLogger.level: INFO
+      logger.connect.name: org.apache.kafka.connect
+      logger.connect.level: DEBUG
+      logger.runtime.name: org.apache.kafka.connect.runtime
+      logger.runtime.level: WARN
 ```
+
+Each custom logger needs a `logger.<key>.name` line that declares the package it targets, plus a `logger.<key>.level` line that sets the level. The `<key>` is an arbitrary identifier used only inside the `loggers` map.
 
 External logging using a ConfigMap:
 
@@ -331,13 +361,13 @@ spec:
     valueFrom:
       configMapKeyRef:
         name: my-connect-logging
-        key: log4j.properties
+        key: log4j2.properties
 ```
 
-Create the ConfigMap before applying the `KafkaConnect` resource:
+Create the ConfigMap before applying the `KafkaConnect` resource. The ConfigMap must contain a full log4j2 configuration:
 
 ```bash
-kubectl -n default create configmap my-connect-logging --from-file=log4j.properties=./log4j.properties
+kubectl -n default create configmap my-connect-logging --from-file=log4j2.properties=./log4j2.properties
 ```
 
 ## Configure Metrics
@@ -517,25 +547,74 @@ kubectl -n default patch kafkaconnector my-file-source-connector --type merge -p
 
 ## Manage Connector Offsets
 
-You can list, alter, and reset connector offsets through the `KafkaConnector` resource. This is useful for replaying data or skipping problematic records.
+You can list, alter, and reset connector offsets through the `KafkaConnector` resource using `spec.listOffsets` and `spec.alterOffsets`. The operator writes the results to a ConfigMap and reconciles the requested changes, so offset management stays declarative and does not require calling the Kafka Connect REST API.
 
-List current offsets by checking the connector status:
+Offset operations are driven by annotations on the `KafkaConnector` resource:
 
-```bash
-kubectl -n default get kafkaconnector my-file-source-connector -o jsonpath='{.status.connectorStatus}'
+- `strimzi.io/connector-offsets=list` triggers a list operation.
+- `strimzi.io/connector-offsets=alter` triggers an alter operation. The connector must be in the `stopped` state first.
+- `strimzi.io/connector-offsets=reset` triggers a reset operation. The connector must also be `stopped`.
+
+### List Offsets
+
+Declare the target ConfigMap in `spec.listOffsets`, then annotate the resource to trigger the list:
+
+```yaml
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaConnector
+metadata:
+  name: my-file-source-connector
+  labels:
+    strimzi.io/cluster: my-connect-cluster
+spec:
+  class: org.apache.kafka.connect.file.FileStreamSourceConnector
+  tasksMax: 1
+  listOffsets:
+    toConfigMap:
+      name: my-file-source-connector-offsets
+  config:
+    file: /tmp/test.txt
+    topic: my-connect-topic
 ```
 
-To reset offsets, stop the connector first and then use the Kafka Connect REST API:
-
 ```bash
-kubectl -n default port-forward service/my-connect-cluster-connect-api 8083:8083
-curl -X DELETE http://localhost:8083/connectors/my-file-source-connector/offsets
+kubectl -n default annotate kafkaconnector my-file-source-connector \
+  strimzi.io/connector-offsets=list --overwrite
+kubectl -n default get configmap my-file-source-connector-offsets -o yaml
 ```
 
-After resetting offsets, resume the connector. The connector starts processing from the beginning or from the position defined by its offset reset policy.
+### Alter Offsets
+
+To alter offsets, stop the connector, provide the new offsets in a ConfigMap referenced by `spec.alterOffsets`, and annotate the resource:
+
+```yaml
+spec:
+  state: stopped
+  alterOffsets:
+    fromConfigMap:
+      name: my-file-source-connector-new-offsets
+```
+
+```bash
+kubectl -n default annotate kafkaconnector my-file-source-connector \
+  strimzi.io/connector-offsets=alter --overwrite
+```
+
+### Reset Offsets
+
+To reset offsets, stop the connector and annotate the resource:
+
+```bash
+kubectl -n default patch kafkaconnector my-file-source-connector \
+  --type merge -p '{"spec":{"state":"stopped"}}'
+kubectl -n default annotate kafkaconnector my-file-source-connector \
+  strimzi.io/connector-offsets=reset --overwrite
+```
+
+After the reset or alter operation completes, return the connector to `running`. The connector resumes processing from the new offset position or from the position defined by its offset reset policy.
 
 <Directive type="warning" title="Warning">
-Resetting offsets can cause data to be reprocessed. Only reset offsets when you understand the impact on downstream consumers and the external system.
+Altering or resetting offsets can cause data to be reprocessed or skipped. Only do this when you understand the impact on downstream consumers and the external system.
 </Directive>
 
 ## Delete a Connector
@@ -565,7 +644,7 @@ Deleting a connector does not automatically delete Kafka topics, committed offse
 | `spec.config.offset.storage.topic` | Topic used to store connector offsets. |
 | `spec.config.status.storage.topic` | Topic used to store connector and task status. |
 | `spec.build` | Optional build configuration for adding connector plugins. |
-| `spec.externalConfiguration` | Mount Secrets or ConfigMaps into Kafka Connect pods for connector credential access. Deprecated in favor of environment variables. |
+| `spec.externalConfiguration` | Mount Secrets or ConfigMaps into Kafka Connect pods for connector credential access. Being phased out; use `spec.template.pod.volumes` with `spec.template.connectContainer.volumeMounts` for file-based secrets, or `spec.template.connectContainer.env` for environment variables. |
 | `spec.logging` | Logging configuration. Supports inline loggers or an external ConfigMap reference. |
 | `spec.metricsConfig` | Prometheus JMX exporter configuration for metrics collection. |
 | `spec.tracing` | Distributed tracing configuration. Supports OpenTelemetry. |
@@ -586,6 +665,8 @@ Deleting a connector does not automatically delete Kafka topics, committed offse
 | `spec.config` | Connector-specific configuration. |
 | `spec.state` | Desired connector state. Supported values are `running`, `paused`, and `stopped`. |
 | `spec.autoRestart` | Automatic restart policy for failed connectors or tasks. Set `enabled: true` and optionally `maxRestarts` to limit consecutive restarts. |
+| `spec.listOffsets` | Target ConfigMap for list-offsets operations. Triggered by the `strimzi.io/connector-offsets=list` annotation. |
+| `spec.alterOffsets` | Source ConfigMap for alter-offsets operations. Triggered by the `strimzi.io/connector-offsets=alter` annotation. The connector must be in the `stopped` state. |
 
 ## Best Practices
 

--- a/docs/en/how_to/35-kafka-connect.mdx
+++ b/docs/en/how_to/35-kafka-connect.mdx
@@ -8,6 +8,10 @@ Kafka Connect is a component of the Strimzi operator used to run Kafka source an
 
 This document describes how to create a `KafkaConnect` cluster, add connector plugins, create `KafkaConnector` resources, and manage connector lifecycle.
 
+<Directive type="note" title="Note">
+The examples in this document use `default` as the namespace. In production environments, deploy Kafka Connect in a dedicated namespace. Replace `default` with the namespace used in your environment.
+</Directive>
+
 ## Prerequisites
 
 Before creating Kafka Connect, ensure that the following conditions are met:
@@ -124,68 +128,9 @@ spec:
     output:
       type: docker
       image: registry.example.com/kafka/my-connect-cluster:latest
-    plugins:
-      - name: kafka-connect-file
-        artifacts:
-          - type: maven
-            group: org.apache.kafka
-            artifact: connect-file
-            version: 4.1.1
-  config:
-    group.id: my-connect-cluster
-    config.storage.topic: my-connect-cluster-configs
-    offset.storage.topic: my-connect-cluster-offsets
-    status.storage.topic: my-connect-cluster-status
-    config.storage.replication.factor: 3
-    offset.storage.replication.factor: 3
-    status.storage.replication.factor: 3
-```
-
-## Check Available Connector Plugins
-
-Before creating a connector, verify that the connector plugin is available in the Kafka Connect cluster.
-
-```bash
-kubectl -n default port-forward service/my-connect-cluster-connect-api 8083:8083
-curl http://localhost:8083/connector-plugins
-```
-
-The output should include the connector class that you plan to use, for example `org.apache.kafka.connect.file.FileStreamSourceConnector` or a connector class provided by your plugin.
-
-Only create a connector after its class appears in `/connector-plugins`. In the current product image, the default plugin list can contain only MirrorMaker 2 connector classes. A connector JAR present in the image classpath does not automatically mean that the connector is available for use through Kafka Connect plugin discovery.
-
-## If the Connector Class Does Not Exist
-
-If the connector class you need is not listed in `/connector-plugins`, do not create the `KafkaConnector` yet. Add the plugin to the Kafka Connect runtime first, then check `/connector-plugins` again.
-
-Use one of the following approaches:
-
-1. Recommended: use `spec.build` to let Strimzi build a new Kafka Connect image with the required plugin and push it to your registry.
-2. Use a prebuilt custom image that already contains the required plugin, then set `spec.image`.
-3. Upstream Strimzi also supports `spec.plugins` with `type: image`, which uses Kubernetes Image Volumes to mount an OCI artifact into `/opt/kafka/plugins`. In the current product test cluster, this path was accepted by the CRD but did not expose the connector class through `/connector-plugins`, so do not use it as the default procedure unless you validate it successfully in your own environment.
-
-The `spec.build` approach is the most predictable because the plugin becomes part of the resulting image and can be promoted across environments.
-
-The following example shows the recommended build pattern using a Maven artifact:
-
-```yaml
-apiVersion: kafka.strimzi.io/v1beta2
-kind: KafkaConnect
-metadata:
-  name: my-connect-cluster
-  annotations:
-    strimzi.io/use-connector-resources: "true"
-spec:
-  version: 4.1.1
-  replicas: 2
-  bootstrapServers: my-cluster-kafka-bootstrap:9092
-  build:
-    output:
-      type: docker
-      image: registry.example.com/kafka/my-connect-cluster:latest
       pushSecret: my-registry-secret
     plugins:
-      - name: my-jdbc-plugin
+      - name: kafka-connect-file
         artifacts:
           - type: maven
             repository: https://repo1.maven.org/maven2
@@ -226,6 +171,31 @@ spec:
     status.storage.replication.factor: 3
 ```
 
+## Check Available Connector Plugins
+
+Before creating a connector, verify that the connector plugin is available in the Kafka Connect cluster.
+
+```bash
+kubectl -n default port-forward service/my-connect-cluster-connect-api 8083:8083
+curl http://localhost:8083/connector-plugins
+```
+
+The output should include the connector class that you plan to use, for example `org.apache.kafka.connect.file.FileStreamSourceConnector` or a connector class provided by your plugin.
+
+Only create a connector after its class appears in `/connector-plugins`. In the current product image, the default plugin list can contain only MirrorMaker 2 connector classes. A connector JAR present in the image classpath does not automatically mean that the connector is available for use through Kafka Connect plugin discovery.
+
+## If the Connector Class Does Not Exist
+
+If the connector class you need is not listed in `/connector-plugins`, do not create the `KafkaConnector` yet. Add the plugin to the Kafka Connect runtime first, then check `/connector-plugins` again.
+
+Use one of the following approaches:
+
+1. Recommended: use `spec.build` to let Strimzi build a new Kafka Connect image with the required plugin and push it to your registry. See the build example in [Add Connector Plugins](#add-connector-plugins).
+2. Use a prebuilt custom image that already contains the required plugin, then set `spec.image`.
+3. Upstream Strimzi also supports `spec.plugins` with `type: image`, which uses Kubernetes Image Volumes to mount an OCI artifact into `/opt/kafka/plugins`. In the current product test cluster, this path was accepted by the CRD but did not expose the connector class through `/connector-plugins`, so do not use it as the default procedure unless you validate it successfully in your own environment.
+
+The `spec.build` approach is the most predictable because the plugin becomes part of the resulting image and can be promoted across environments.
+
 After changing the image source, wait for the Kafka Connect pod rollout to finish and run `/connector-plugins` again. Only create the `KafkaConnector` after the required class appears in the returned list.
 
 ## Create a Source Connector
@@ -249,11 +219,16 @@ metadata:
 spec:
   class: org.apache.kafka.connect.file.FileStreamSourceConnector
   tasksMax: 1
+  autoRestart:
+    enabled: true
+    maxRestarts: 10
   config:
     file: /tmp/test.txt
     topic: my-connect-topic
 EOF
 ```
+
+The `autoRestart` field enables automatic restart for failed connectors and tasks. Set `maxRestarts` to limit the number of consecutive automatic restarts. If the connector exceeds the maximum restart count, it remains in a failed state until the issue is resolved and the connector is manually restarted.
 
 ## Create a Sink Connector
 
@@ -269,6 +244,8 @@ metadata:
 spec:
   class: com.example.connect.MySinkConnector
   tasksMax: 2
+  autoRestart:
+    enabled: true
   config:
     topics: my-source-topic
     connection.url: jdbc:postgresql://postgresql.default.svc:5432/app
@@ -277,6 +254,198 @@ spec:
 ```
 
 If the connector needs secrets, mount them into the `KafkaConnect` cluster through external configuration and reference them from connector configuration. Avoid storing passwords directly in the `KafkaConnector` resource.
+
+## Configure External Secrets for Connectors
+
+To use `${file:...}` references in connector configuration, mount secrets into the Kafka Connect pods using `spec.externalConfiguration`. The following example mounts a Kubernetes Secret as a volume so that connectors can read credentials from a properties file.
+
+```yaml
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaConnect
+metadata:
+  name: my-connect-cluster
+  annotations:
+    strimzi.io/use-connector-resources: "true"
+spec:
+  version: 4.1.1
+  replicas: 2
+  bootstrapServers: my-cluster-kafka-bootstrap:9092
+  config:
+    group.id: my-connect-cluster
+    config.storage.topic: my-connect-cluster-configs
+    offset.storage.topic: my-connect-cluster-offsets
+    status.storage.topic: my-connect-cluster-status
+    config.storage.replication.factor: 3
+    offset.storage.replication.factor: 3
+    status.storage.replication.factor: 3
+    config.providers: file
+    config.providers.file.class: org.apache.kafka.common.config.provider.FileConfigProvider
+  externalConfiguration:
+    volumes:
+      - name: connector-secrets
+        secret:
+          secretName: my-connector-secrets
+```
+
+Connectors reference mounted secrets using the `${file:/opt/kafka/external-configuration/<volume-name>/<file>:<key>}` syntax.
+
+You can also pass secrets as environment variables:
+
+```yaml
+spec:
+  externalConfiguration:
+    env:
+      - name: DB_PASSWORD
+        valueFrom:
+          secretKeyRef:
+            name: my-connector-secrets
+            key: password
+```
+
+<Directive type="note" title="Deprecation Notice">
+The `externalConfiguration` property is deprecated in newer Strimzi versions. Use `spec.template.connectContainer.env` with `valueFrom.secretKeyRef` or `valueFrom.configMapKeyRef` for new deployments. Existing `externalConfiguration` setups continue to work but should be migrated.
+</Directive>
+
+## Configure Logging
+
+Use `spec.logging` to configure the log levels for Kafka Connect workers. You can use inline logging or reference an external ConfigMap.
+
+Inline logging:
+
+```yaml
+spec:
+  logging:
+    type: inline
+    loggers:
+      log4j.rootLogger: INFO
+      log4j.logger.org.apache.kafka.connect: DEBUG
+      log4j.logger.org.apache.kafka.connect.runtime: WARN
+```
+
+External logging using a ConfigMap:
+
+```yaml
+spec:
+  logging:
+    type: external
+    valueFrom:
+      configMapKeyRef:
+        name: my-connect-logging
+        key: log4j.properties
+```
+
+Create the ConfigMap before applying the `KafkaConnect` resource:
+
+```bash
+kubectl -n default create configmap my-connect-logging --from-file=log4j.properties=./log4j.properties
+```
+
+## Configure Metrics
+
+Enable Prometheus metrics collection using `spec.metricsConfig`. Metrics are exported through a JMX Prometheus exporter sidecar.
+
+```yaml
+spec:
+  metricsConfig:
+    type: jmxPrometheusExporter
+    valueFrom:
+      configMapKeyRef:
+        name: my-connect-metrics
+        key: metrics-config.yml
+```
+
+Create the metrics ConfigMap with JMX exporter rules:
+
+```bash
+kubectl -n default create configmap my-connect-metrics --from-file=metrics-config.yml=./metrics-config.yml
+```
+
+Example `metrics-config.yml`:
+
+```yaml
+lowercaseOutputName: true
+lowercaseOutputLabelNames: true
+rules:
+  - pattern: "kafka.connect<type=connect-worker-metrics>([^:]+):"
+    name: "kafka_connect_worker_$1"
+  - pattern: "kafka.connect<type=connect-metrics, client-id=(.+)><>([^:]+)"
+    name: "kafka_connect_$2"
+    labels:
+      client_id: "$1"
+```
+
+After metrics are enabled, configure a Prometheus `ServiceMonitor` or `PodMonitor` to scrape the metrics endpoint. Use Grafana dashboards to visualize Kafka Connect worker and connector metrics.
+
+## Configure Distributed Tracing
+
+Enable OpenTelemetry distributed tracing to track messages through Kafka Connect pipelines.
+
+```yaml
+spec:
+  tracing:
+    type: opentelemetry
+```
+
+Set the OpenTelemetry endpoint through environment variables in the Kafka Connect template:
+
+```yaml
+spec:
+  tracing:
+    type: opentelemetry
+  template:
+    connectContainer:
+      env:
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: http://otel-collector.observability.svc:4317
+        - name: OTEL_SERVICE_NAME
+          value: my-connect-cluster
+```
+
+Only messages produced and consumed by Kafka Connect itself are traced. Messages already in Kafka topics before tracing is enabled are not retroactively traced.
+
+## Configure Rack Awareness
+
+Configure rack awareness so that Kafka Connect workers consume from the closest Kafka broker replicas. This reduces cross-zone network traffic in multi-zone deployments.
+
+```yaml
+spec:
+  rack:
+    topologyKey: topology.kubernetes.io/zone
+```
+
+The `topologyKey` value must match a node label present on all Kubernetes nodes where Kafka Connect pods can be scheduled.
+
+## Configure JVM Options
+
+Tune JVM memory allocation and garbage collection for Kafka Connect workers using `spec.jvmOptions`.
+
+```yaml
+spec:
+  jvmOptions:
+    -Xms: 1g
+    -Xmx: 2g
+    gcLoggingEnabled: true
+```
+
+Set `-Xms` and `-Xmx` according to the `spec.resources.requests.memory` and `spec.resources.limits.memory` values. Leave enough memory for non-heap usage such as thread stacks and native memory.
+
+## Configure Health Checks
+
+Customize liveness and readiness probe settings if the default values do not match your environment.
+
+```yaml
+spec:
+  livenessProbe:
+    initialDelaySeconds: 60
+    timeoutSeconds: 5
+    periodSeconds: 10
+  readinessProbe:
+    initialDelaySeconds: 60
+    timeoutSeconds: 5
+    periodSeconds: 10
+```
+
+Increase `initialDelaySeconds` if Kafka Connect workers take longer to start, for example when loading large connector plugins.
 
 ## Verify Kafka Connect and Connectors
 
@@ -346,6 +515,29 @@ Stop the connector by setting `spec.state` to `stopped`.
 kubectl -n default patch kafkaconnector my-file-source-connector --type merge -p '{"spec":{"state":"stopped"}}'
 ```
 
+## Manage Connector Offsets
+
+You can list, alter, and reset connector offsets through the `KafkaConnector` resource. This is useful for replaying data or skipping problematic records.
+
+List current offsets by checking the connector status:
+
+```bash
+kubectl -n default get kafkaconnector my-file-source-connector -o jsonpath='{.status.connectorStatus}'
+```
+
+To reset offsets, stop the connector first and then use the Kafka Connect REST API:
+
+```bash
+kubectl -n default port-forward service/my-connect-cluster-connect-api 8083:8083
+curl -X DELETE http://localhost:8083/connectors/my-file-source-connector/offsets
+```
+
+After resetting offsets, resume the connector. The connector starts processing from the beginning or from the position defined by its offset reset policy.
+
+<Directive type="warning" title="Warning">
+Resetting offsets can cause data to be reprocessed. Only reset offsets when you understand the impact on downstream consumers and the external system.
+</Directive>
+
 ## Delete a Connector
 
 Delete the `KafkaConnector` resource to remove the connector instance from Kafka Connect:
@@ -358,23 +550,42 @@ Deleting a connector does not automatically delete Kafka topics, committed offse
 
 ## Key Configuration Parameters
 
+### KafkaConnect Resource
+
 | Parameter | Description |
 | :--- | :--- |
 | `spec.replicas` | Number of Kafka Connect worker pods. |
+| `spec.version` | Kafka Connect version. Defaults to the latest version supported by the operator. |
+| `spec.image` | Custom container image for Kafka Connect pods. |
 | `spec.bootstrapServers` | Kafka bootstrap server used by Kafka Connect. |
 | `spec.tls` | TLS configuration for encrypted Kafka connections. |
-| `spec.authentication` | Authentication configuration, such as SCRAM-SHA-512 or TLS authentication. |
+| `spec.authentication` | Authentication configuration, such as SCRAM-SHA-512, TLS, or OAuth. |
 | `spec.config.group.id` | Kafka Connect worker group ID. Use a unique value per Kafka Connect cluster. |
 | `spec.config.config.storage.topic` | Topic used to store connector configurations. |
 | `spec.config.offset.storage.topic` | Topic used to store connector offsets. |
 | `spec.config.status.storage.topic` | Topic used to store connector and task status. |
 | `spec.build` | Optional build configuration for adding connector plugins. |
+| `spec.externalConfiguration` | Mount Secrets or ConfigMaps into Kafka Connect pods for connector credential access. Deprecated in favor of environment variables. |
+| `spec.logging` | Logging configuration. Supports inline loggers or an external ConfigMap reference. |
+| `spec.metricsConfig` | Prometheus JMX exporter configuration for metrics collection. |
+| `spec.tracing` | Distributed tracing configuration. Supports OpenTelemetry. |
+| `spec.rack` | Rack awareness configuration for consuming from the closest replicas. |
+| `spec.jvmOptions` | JVM memory and GC options for Kafka Connect pods. |
+| `spec.resources` | CPU and memory resource requests and limits. |
+| `spec.livenessProbe` | Liveness probe configuration for worker pods. |
+| `spec.readinessProbe` | Readiness probe configuration for worker pods. |
+| `spec.template` | Template for customizing pod labels, annotations, affinity rules, and container environment variables. |
+
+### KafkaConnector Resource
+
+| Parameter | Description |
+| :--- | :--- |
 | `metadata.labels.strimzi.io/cluster` | Name of the `KafkaConnect` cluster that runs the connector. |
 | `spec.class` | Connector implementation class. The class must be available in the Kafka Connect image. |
 | `spec.tasksMax` | Maximum number of tasks for the connector. Actual parallelism depends on connector implementation and source or sink system capabilities. |
 | `spec.config` | Connector-specific configuration. |
 | `spec.state` | Desired connector state. Supported values are `running`, `paused`, and `stopped`. |
-| `spec.autoRestart` | Optional automatic restart policy for failed connectors or tasks. |
+| `spec.autoRestart` | Automatic restart policy for failed connectors or tasks. Set `enabled: true` and optionally `maxRestarts` to limit consecutive restarts. |
 
 ## Best Practices
 
@@ -383,10 +594,13 @@ Deleting a connector does not automatically delete Kafka topics, committed offse
 3. Configure internal topic replication factors based on the Kafka cluster size.
 4. Keep connector plugin versions compatible with the Kafka Connect runtime version.
 5. Keep one `KafkaConnector` resource per connector instance.
-6. Avoid storing secrets directly in `spec.config`.
-7. Store passwords and certificates in Kubernetes Secrets instead of plain text connector configuration.
-8. Set `tasksMax` according to connector capabilities and workload size.
-9. Monitor connector task status, restart count, lag, and error logs after deployment.
+6. Avoid storing secrets directly in `spec.config`. Use `externalConfiguration` or environment variables from Kubernetes Secrets.
+7. Set `tasksMax` according to connector capabilities and workload size.
+8. Enable `autoRestart` on all production connectors to recover from transient failures automatically.
+9. Enable Prometheus metrics and configure Grafana dashboards to monitor connector task status, restart count, lag, and error rates.
+10. Configure logging at `INFO` level by default. Use `DEBUG` only for troubleshooting specific connector issues.
+11. Use rack awareness in multi-zone clusters to reduce cross-zone network traffic.
+12. Use `spec.template` to set pod affinity and anti-affinity rules for high availability.
 
 ## Troubleshooting
 
@@ -396,7 +610,9 @@ Deleting a connector does not automatically delete Kafka topics, committed offse
 | Connector class not found | Verify that the plugin is installed and listed by `/connector-plugins`. |
 | Connector is not assigned to a Connect cluster | Verify the `strimzi.io/cluster` label. |
 | Connector stays in `NotReady` | Check whether the connector plugin class exists in `curl /connector-plugins`. |
-| Connector tasks fail or fail repeatedly | Check connector-specific configuration, worker logs, external system connectivity, and task status. |
+| Connector tasks fail or fail repeatedly | Check connector-specific configuration, worker logs, external system connectivity, and task status. Enable `autoRestart` to recover from transient failures. |
 | Connector does not process new data | Check source offsets, topic subscription, task status, and external system permissions. |
 | Authentication fails | Verify `spec.authentication`, Kafka ACLs, connector credentials, mounted secrets, and TLS configuration. |
-| Build fails | Verify registry access, plugin artifact URLs, and image pull permissions. |
+| Build fails | Verify registry access, plugin artifact URLs, push secret permissions, and image pull permissions. |
+| Metrics not available | Verify the metrics ConfigMap exists and `spec.metricsConfig` references the correct key. Check if the Prometheus exporter port is accessible. |
+| Tracing spans not visible | Verify `spec.tracing` is set, the OpenTelemetry collector is reachable, and the `OTEL_EXPORTER_OTLP_ENDPOINT` environment variable is correct. |

--- a/docs/en/how_to/35-kafka-connect.mdx
+++ b/docs/en/how_to/35-kafka-connect.mdx
@@ -1,0 +1,326 @@
+---
+weight: 35
+---
+
+# Using Kafka Connect
+
+Kafka Connect is a component of the Strimzi operator used to run Kafka source and sink connectors on Kubernetes. You can use it to move data between Kafka and external systems such as databases, object storage, search engines, and other message systems.
+
+This document describes how to create a `KafkaConnect` cluster, add connector plugins, create `KafkaConnector` resources, and manage connector lifecycle.
+
+## Prerequisites
+
+Before creating Kafka Connect, ensure that the following conditions are met:
+
+1. The Strimzi operator is installed and watching the namespace where Kafka Connect will be created.
+2. A Kafka cluster is running and reachable from the Kafka Connect pods.
+3. The connector plugin required by your workload is available in the Kafka Connect image or configured through the Kafka Connect build mechanism.
+4. The target Kafka topics and external systems are reachable.
+5. Kafka users, ACLs, and TLS certificates are prepared if the target Kafka cluster enables authentication or TLS.
+
+## Create a Kafka Connect Cluster
+
+The following example creates a Kafka Connect cluster named `my-connect-cluster` and connects it to a Kafka cluster named `my-cluster` through the internal plain bootstrap service.
+
+<Directive type="note" title="Note">
+Replace the namespace, bootstrap address, connector image, and resource settings according to your environment.
+</Directive>
+
+```bash
+cat << EOF | kubectl -n default apply -f -
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaConnect
+metadata:
+  name: my-connect-cluster
+  annotations:
+    strimzi.io/use-connector-resources: "true"
+spec:
+  version: 4.1.1
+  replicas: 2
+  bootstrapServers: my-cluster-kafka-bootstrap:9092
+  config:
+    group.id: my-connect-cluster
+    config.storage.topic: my-connect-cluster-configs
+    offset.storage.topic: my-connect-cluster-offsets
+    status.storage.topic: my-connect-cluster-status
+    config.storage.replication.factor: 3
+    offset.storage.replication.factor: 3
+    status.storage.replication.factor: 3
+    key.converter: org.apache.kafka.connect.json.JsonConverter
+    value.converter: org.apache.kafka.connect.json.JsonConverter
+    key.converter.schemas.enable: false
+    value.converter.schemas.enable: false
+  resources:
+    requests:
+      cpu: 500m
+      memory: 1Gi
+    limits:
+      cpu: 1
+      memory: 2Gi
+EOF
+```
+
+The annotation `strimzi.io/use-connector-resources: "true"` enables connector management through `KafkaConnector` custom resources. With this mode enabled, connector instances are reconciled by the operator instead of being managed only through the Kafka Connect REST API.
+
+## Create a Kafka Connect Cluster with TLS and SCRAM
+
+If the Kafka cluster requires TLS and SCRAM-SHA-512 authentication, configure `tls` and `authentication` in the `KafkaConnect` resource.
+
+```yaml
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaConnect
+metadata:
+  name: my-connect-cluster
+  annotations:
+    strimzi.io/use-connector-resources: "true"
+spec:
+  version: 4.1.1
+  replicas: 2
+  bootstrapServers: my-cluster-kafka-bootstrap:9093
+  tls:
+    trustedCertificates:
+      - secretName: my-cluster-cluster-ca-cert
+        certificate: ca.crt
+  authentication:
+    type: scram-sha-512
+    username: my-connect-user
+    passwordSecret:
+      secretName: my-connect-user
+      password: password
+  config:
+    group.id: my-connect-cluster
+    config.storage.topic: my-connect-cluster-configs
+    offset.storage.topic: my-connect-cluster-offsets
+    status.storage.topic: my-connect-cluster-status
+    config.storage.replication.factor: 3
+    offset.storage.replication.factor: 3
+    status.storage.replication.factor: 3
+```
+
+## Add Connector Plugins
+
+Kafka Connect workers need connector plugins before connector instances can run. Strimzi supports several plugin delivery methods. Use the method that matches your image and registry policy.
+
+| Method | Usage |
+| :--- | :--- |
+| Custom image | Build a Kafka Connect image that already contains connector plugins, then set `spec.image`. |
+| Kafka Connect build | Let Strimzi build a Kafka Connect image from plugin artifacts and push it to a configured registry. |
+| Mounted plugins | Mount plugin artifacts from volumes when this is supported by your environment. |
+
+The following example shows the Strimzi build pattern using a Maven artifact. Replace the registry, artifact URL, and checksum with values approved in your environment.
+
+```yaml
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaConnect
+metadata:
+  name: my-connect-cluster
+  annotations:
+    strimzi.io/use-connector-resources: "true"
+spec:
+  version: 4.1.1
+  replicas: 2
+  bootstrapServers: my-cluster-kafka-bootstrap:9092
+  build:
+    output:
+      type: docker
+      image: registry.example.com/kafka/my-connect-cluster:latest
+    plugins:
+      - name: kafka-connect-file
+        artifacts:
+          - type: maven
+            group: org.apache.kafka
+            artifact: connect-file
+            version: 4.1.1
+  config:
+    group.id: my-connect-cluster
+    config.storage.topic: my-connect-cluster-configs
+    offset.storage.topic: my-connect-cluster-offsets
+    status.storage.topic: my-connect-cluster-status
+    config.storage.replication.factor: 3
+    offset.storage.replication.factor: 3
+    status.storage.replication.factor: 3
+```
+
+## Check Available Connector Plugins
+
+Before creating a connector, verify that the connector plugin is available in the Kafka Connect cluster.
+
+```bash
+kubectl -n default port-forward service/my-connect-cluster-connect-api 8083:8083
+curl http://localhost:8083/connector-plugins
+```
+
+The output should include the connector class that you plan to use, for example `org.apache.kafka.connect.file.FileStreamSourceConnector` or a connector class provided by your plugin.
+
+## Create a Source Connector
+
+After the Kafka Connect cluster is ready and the required plugin is available, create a `KafkaConnector` resource.
+
+The `strimzi.io/cluster` label must match the name of the `KafkaConnect` resource.
+
+<Directive type="note" title="Example Only">
+The file connector is useful for validating the Kafka Connect workflow. For production workloads, use the connector plugin required by your data source, such as a change data capture connector or a relational database connector.
+</Directive>
+
+```bash
+cat << EOF | kubectl -n default apply -f -
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaConnector
+metadata:
+  name: my-file-source-connector
+  labels:
+    strimzi.io/cluster: my-connect-cluster
+spec:
+  class: org.apache.kafka.connect.file.FileStreamSourceConnector
+  tasksMax: 1
+  config:
+    file: /tmp/test.txt
+    topic: my-connect-topic
+EOF
+```
+
+## Create a Sink Connector
+
+The following example shows the structure of a sink connector. Replace the connector class and configuration with the plugin used in your environment.
+
+```yaml
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaConnector
+metadata:
+  name: my-sink-connector
+  labels:
+    strimzi.io/cluster: my-connect-cluster
+spec:
+  class: com.example.connect.MySinkConnector
+  tasksMax: 2
+  config:
+    topics: my-source-topic
+    connection.url: jdbc:postgresql://postgresql.default.svc:5432/app
+    connection.user: ${file:/opt/kafka/external-configuration/connector-secrets/db.properties:username}
+    connection.password: ${file:/opt/kafka/external-configuration/connector-secrets/db.properties:password}
+```
+
+If the connector needs secrets, mount them into the `KafkaConnect` cluster through external configuration and reference them from connector configuration. Avoid storing passwords directly in the `KafkaConnector` resource.
+
+## Verify Kafka Connect and Connectors
+
+Check the Kafka Connect cluster status:
+
+```bash
+kubectl -n default get kafkaconnect my-connect-cluster
+kubectl -n default describe kafkaconnect my-connect-cluster
+```
+
+Check connector status:
+
+```bash
+kubectl -n default get kafkaconnector
+kubectl -n default describe kafkaconnector my-file-source-connector
+kubectl -n default get kafkaconnector my-file-source-connector -o yaml
+```
+
+Check worker pods:
+
+```bash
+kubectl -n default get pods -l strimzi.io/name=my-connect-cluster-connect
+```
+
+Check the Kafka Connect worker logs if the connector is not ready:
+
+```bash
+kubectl -n default logs -l strimzi.io/name=my-connect-cluster-connect
+```
+
+## Update a Connector
+
+Update a connector by editing the `KafkaConnector` resource:
+
+```bash
+kubectl -n default edit kafkaconnector my-file-source-connector
+```
+
+The operator reconciles the change and updates the connector through the Kafka Connect REST API.
+
+Common updates include:
+
+- Changing `tasksMax`
+- Updating connector-specific configuration
+- Adding topic patterns
+- Adjusting connector retry or error-handling parameters
+
+## Pause, Resume, and Stop a Connector
+
+Use `spec.state` to control whether a connector is running, paused, or stopped.
+
+Pause a connector by setting `spec.state` to `paused`.
+
+```bash
+kubectl -n default patch kafkaconnector my-file-source-connector --type merge -p '{"spec":{"state":"paused"}}'
+```
+
+Resume the connector by setting `spec.state` to `running`.
+
+```bash
+kubectl -n default patch kafkaconnector my-file-source-connector --type merge -p '{"spec":{"state":"running"}}'
+```
+
+Stop the connector by setting `spec.state` to `stopped`.
+
+```bash
+kubectl -n default patch kafkaconnector my-file-source-connector --type merge -p '{"spec":{"state":"stopped"}}'
+```
+
+## Delete a Connector
+
+Delete the `KafkaConnector` resource to remove the connector instance from Kafka Connect:
+
+```bash
+kubectl -n default delete kafkaconnector my-file-source-connector
+```
+
+Deleting a connector does not automatically delete Kafka topics, committed offsets, or data in the external system.
+
+## Key Configuration Parameters
+
+| Parameter | Description |
+| :--- | :--- |
+| `spec.replicas` | Number of Kafka Connect worker pods. |
+| `spec.bootstrapServers` | Kafka bootstrap server used by Kafka Connect. |
+| `spec.tls` | TLS configuration for encrypted Kafka connections. |
+| `spec.authentication` | Authentication configuration, such as SCRAM-SHA-512 or TLS authentication. |
+| `spec.config.group.id` | Kafka Connect worker group ID. Use a unique value per Kafka Connect cluster. |
+| `spec.config.config.storage.topic` | Topic used to store connector configurations. |
+| `spec.config.offset.storage.topic` | Topic used to store connector offsets. |
+| `spec.config.status.storage.topic` | Topic used to store connector and task status. |
+| `spec.build` | Optional build configuration for adding connector plugins. |
+| `metadata.labels.strimzi.io/cluster` | Name of the `KafkaConnect` cluster that runs the connector. |
+| `spec.class` | Connector implementation class. The class must be available in the Kafka Connect image. |
+| `spec.tasksMax` | Maximum number of tasks for the connector. Actual parallelism depends on connector implementation and source or sink system capabilities. |
+| `spec.config` | Connector-specific configuration. |
+| `spec.state` | Desired connector state. Supported values are `running`, `paused`, and `stopped`. |
+| `spec.autoRestart` | Optional automatic restart policy for failed connectors or tasks. |
+
+## Best Practices
+
+1. Use `KafkaConnector` resources for connector lifecycle management instead of manually creating connectors through the REST API.
+2. Use at least `2` Kafka Connect replicas for production workloads.
+3. Configure internal topic replication factors based on the Kafka cluster size.
+4. Keep connector plugin versions compatible with the Kafka Connect runtime version.
+5. Keep one `KafkaConnector` resource per connector instance.
+6. Avoid storing secrets directly in `spec.config`.
+7. Store passwords and certificates in Kubernetes Secrets instead of plain text connector configuration.
+8. Set `tasksMax` according to connector capabilities and workload size.
+9. Monitor connector task status, restart count, lag, and error logs after deployment.
+
+## Troubleshooting
+
+| Symptom | Check |
+| :--- | :--- |
+| `KafkaConnect` is not ready | Check `kubectl describe kafkaconnect`, worker pod logs, and Kafka bootstrap connectivity. |
+| Connector class not found | Verify that the plugin is installed and listed by `/connector-plugins`. |
+| Connector is not assigned to a Connect cluster | Verify the `strimzi.io/cluster` label. |
+| Connector stays in `NotReady` | Check whether the connector plugin class exists in `curl /connector-plugins`. |
+| Connector tasks fail or fail repeatedly | Check connector-specific configuration, worker logs, external system connectivity, and task status. |
+| Connector does not process new data | Check source offsets, topic subscription, task status, and external system permissions. |
+| Authentication fails | Verify `spec.authentication`, Kafka ACLs, connector credentials, mounted secrets, and TLS configuration. |
+| Build fails | Verify registry access, plugin artifact URLs, and image pull permissions. |

--- a/docs/en/how_to/35-kafka-connect.mdx
+++ b/docs/en/how_to/35-kafka-connect.mdx
@@ -105,7 +105,7 @@ Kafka Connect workers need connector plugins before connector instances can run.
 | :--- | :--- |
 | Custom image | Build a Kafka Connect image that already contains connector plugins, then set `spec.image`. |
 | Kafka Connect build | Let Strimzi build a Kafka Connect image from plugin artifacts and push it to a configured registry. |
-| Mounted plugins | Mount plugin artifacts from volumes when this is supported by your environment. |
+| Image-mounted plugins | Upstream Strimzi can mount plugin OCI artifacts through `spec.plugins`, but validate this carefully in your product build before using it. |
 
 The following example shows the Strimzi build pattern using a Maven artifact. Replace the registry, artifact URL, and checksum with values approved in your environment.
 
@@ -152,6 +152,82 @@ curl http://localhost:8083/connector-plugins
 
 The output should include the connector class that you plan to use, for example `org.apache.kafka.connect.file.FileStreamSourceConnector` or a connector class provided by your plugin.
 
+Only create a connector after its class appears in `/connector-plugins`. In the current product image, the default plugin list can contain only MirrorMaker 2 connector classes. A connector JAR present in the image classpath does not automatically mean that the connector is available for use through Kafka Connect plugin discovery.
+
+## If the Connector Class Does Not Exist
+
+If the connector class you need is not listed in `/connector-plugins`, do not create the `KafkaConnector` yet. Add the plugin to the Kafka Connect runtime first, then check `/connector-plugins` again.
+
+Use one of the following approaches:
+
+1. Recommended: use `spec.build` to let Strimzi build a new Kafka Connect image with the required plugin and push it to your registry.
+2. Use a prebuilt custom image that already contains the required plugin, then set `spec.image`.
+3. Upstream Strimzi also supports `spec.plugins` with `type: image`, which uses Kubernetes Image Volumes to mount an OCI artifact into `/opt/kafka/plugins`. In the current product test cluster, this path was accepted by the CRD but did not expose the connector class through `/connector-plugins`, so do not use it as the default procedure unless you validate it successfully in your own environment.
+
+The `spec.build` approach is the most predictable because the plugin becomes part of the resulting image and can be promoted across environments.
+
+The following example shows the recommended build pattern using a Maven artifact:
+
+```yaml
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaConnect
+metadata:
+  name: my-connect-cluster
+  annotations:
+    strimzi.io/use-connector-resources: "true"
+spec:
+  version: 4.1.1
+  replicas: 2
+  bootstrapServers: my-cluster-kafka-bootstrap:9092
+  build:
+    output:
+      type: docker
+      image: registry.example.com/kafka/my-connect-cluster:latest
+      pushSecret: my-registry-secret
+    plugins:
+      - name: my-jdbc-plugin
+        artifacts:
+          - type: maven
+            repository: https://repo1.maven.org/maven2
+            group: org.apache.kafka
+            artifact: connect-file
+            version: 4.1.1
+  config:
+    group.id: my-connect-cluster
+    config.storage.topic: my-connect-cluster-configs
+    offset.storage.topic: my-connect-cluster-offsets
+    status.storage.topic: my-connect-cluster-status
+    config.storage.replication.factor: 3
+    offset.storage.replication.factor: 3
+    status.storage.replication.factor: 3
+```
+
+If you already have an image built outside the cluster, point Kafka Connect to it directly:
+
+```yaml
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaConnect
+metadata:
+  name: my-connect-cluster
+  annotations:
+    strimzi.io/use-connector-resources: "true"
+spec:
+  version: 4.1.1
+  image: registry.example.com/kafka/my-connect-cluster:latest
+  replicas: 2
+  bootstrapServers: my-cluster-kafka-bootstrap:9092
+  config:
+    group.id: my-connect-cluster
+    config.storage.topic: my-connect-cluster-configs
+    offset.storage.topic: my-connect-cluster-offsets
+    status.storage.topic: my-connect-cluster-status
+    config.storage.replication.factor: 3
+    offset.storage.replication.factor: 3
+    status.storage.replication.factor: 3
+```
+
+After changing the image source, wait for the Kafka Connect pod rollout to finish and run `/connector-plugins` again. Only create the `KafkaConnector` after the required class appears in the returned list.
+
 ## Create a Source Connector
 
 After the Kafka Connect cluster is ready and the required plugin is available, create a `KafkaConnector` resource.
@@ -159,7 +235,7 @@ After the Kafka Connect cluster is ready and the required plugin is available, c
 The `strimzi.io/cluster` label must match the name of the `KafkaConnect` resource.
 
 <Directive type="note" title="Example Only">
-The file connector is useful for validating the Kafka Connect workflow. For production workloads, use the connector plugin required by your data source, such as a change data capture connector or a relational database connector.
+The file connector is useful for validating the Kafka Connect workflow, but only after the `org.apache.kafka.connect.file.FileStreamSourceConnector` class is available in `/connector-plugins`, for example by using the Kafka Connect build example above or a custom image. For production workloads, use the connector plugin required by your data source, such as a change data capture connector or a relational database connector.
 </Directive>
 
 ```bash

--- a/docs/en/how_to/35-kafka-connect.mdx
+++ b/docs/en/how_to/35-kafka-connect.mdx
@@ -101,7 +101,7 @@ spec:
     status.storage.replication.factor: 3
 ```
 
-## Add Connector Plugins
+## Add Connector Plugins \{#add-connector-plugins}
 
 Kafka Connect workers need connector plugins before connector instances can run. Strimzi supports several plugin delivery methods. Use the method that matches your image and registry policy.
 

--- a/docs/en/how_to/35-kafka-connect.mdx
+++ b/docs/en/how_to/35-kafka-connect.mdx
@@ -16,7 +16,7 @@ The examples in this document use `default` as the namespace. In production envi
 
 Before creating Kafka Connect, ensure that the following conditions are met:
 
-1. The Strimzi operator is installed and watching the namespace where Kafka Connect will be created.
+1. The Kafka operator is installed and watching the namespace where Kafka Connect will be created.
 2. A Kafka cluster is running and reachable from the Kafka Connect pods.
 3. The connector plugin required by your workload is available in the Kafka Connect image or configured through the Kafka Connect build mechanism.
 4. The target Kafka topics and external systems are reachable.
@@ -303,10 +303,10 @@ spec:
 ```
 
 <Directive type="note" title="Migration Guidance">
-In newer Strimzi versions, `spec.externalConfiguration` is being phased out in favor of standard pod template fields. Existing `externalConfiguration` setups continue to work, but new deployments should use the following alternatives:
+In newer versions, `spec.externalConfiguration` is being phased out in favor of standard pod template fields. Existing `externalConfiguration` setups continue to work, but new deployments should use the following alternatives:
 
 - For environment variables sourced from a Secret or ConfigMap, use `spec.template.connectContainer.env` with `valueFrom.secretKeyRef` or `valueFrom.configMapKeyRef`.
-- For file-based secrets used with `${file:...}` references, mount the Secret or ConfigMap through `spec.template.pod.volumes` and `spec.template.connectContainer.volumeMounts`. Additional volumes are mounted under `/mnt`, so connector configuration must reference files through that path.
+- For file-based secrets used with `${file:...}` references, mount the Secret or ConfigMap through `spec.template.pod.volumes` and `spec.template.connectContainer.volumeMounts`. Choose a mount path that matches your connector configuration and reference files through that path.
 
 The following example mounts a Secret at `/mnt/connector-secrets` so that connectors can read credentials from a properties file:
 
@@ -675,7 +675,7 @@ Deleting a connector does not automatically delete Kafka topics, committed offse
 3. Configure internal topic replication factors based on the Kafka cluster size.
 4. Keep connector plugin versions compatible with the Kafka Connect runtime version.
 5. Keep one `KafkaConnector` resource per connector instance.
-6. Avoid storing secrets directly in `spec.config`. Use `externalConfiguration` or environment variables from Kubernetes Secrets.
+6. Avoid storing secrets directly in `spec.config`. Prefer `spec.template.connectContainer.env` for environment variables and `spec.template.pod.volumes` with `spec.template.connectContainer.volumeMounts` for file-based secrets. Use `externalConfiguration` only when you need compatibility with existing deployments.
 7. Set `tasksMax` according to connector capabilities and workload size.
 8. Enable `autoRestart` on all production connectors to recover from transient failures automatically.
 9. Enable Prometheus metrics and configure Grafana dashboards to monitor connector task status, restart count, lag, and error rates.

--- a/docs/en/how_to/37-kafka-bridge.mdx
+++ b/docs/en/how_to/37-kafka-bridge.mdx
@@ -107,7 +107,7 @@ These settings apply as defaults for all consumers and producers created through
 
 ## Configure Logging
 
-Use `spec.logging` to configure log levels for Kafka Bridge.
+Kafka Bridge uses log4j2. Use `spec.logging` to configure log levels. Both inline and external configuration follow the log4j2 property syntax.
 
 Inline logging:
 
@@ -116,9 +116,16 @@ spec:
   logging:
     type: inline
     loggers:
+      rootLogger.level: INFO
+      logger.bridge.name: io.strimzi.kafka.bridge
       logger.bridge.level: INFO
+      logger.healthy.name: http.openapi.operation.healthy
       logger.healthy.level: WARN
+      logger.ready.name: http.openapi.operation.ready
+      logger.ready.level: WARN
 ```
+
+Each custom logger requires a `logger.<key>.name` line that declares the target package or logger, plus a `logger.<key>.level` line that sets the level. The `<key>` is an arbitrary identifier used only inside the `loggers` map.
 
 External logging using a ConfigMap:
 
@@ -316,7 +323,7 @@ Use the admin API to create a topic through the Kafka Bridge.
 
 ```bash
 curl -X POST http://localhost:8080/admin/topics \
-  -H 'content-type: application/json' \
+  -H 'content-type: application/vnd.kafka.json.v2+json' \
   -d '{
     "topic_name": "my-new-topic",
     "partitions_count": 3,
@@ -324,14 +331,15 @@ curl -X POST http://localhost:8080/admin/topics \
   }'
 ```
 
+Only `topic_name` is required. If `partitions_count` or `replication_factor` is omitted, the Kafka cluster defaults are used.
+
 ### Common Content Types
 
 | Content Type | Usage |
 | :--- | :--- |
 | `application/vnd.kafka.v2+json` | Consumer creation, subscription, and general API requests. |
-| `application/vnd.kafka.json.v2+json` | Producing or consuming JSON records. |
+| `application/vnd.kafka.json.v2+json` | Producing or consuming JSON records, and admin API requests such as topic creation. |
 | `application/vnd.kafka.binary.v2+json` | Producing or consuming Base64 encoded binary records. |
-| `application/json` | Admin API requests such as topic creation. |
 
 ## Expose Kafka Bridge by Service
 

--- a/docs/en/how_to/37-kafka-bridge.mdx
+++ b/docs/en/how_to/37-kafka-bridge.mdx
@@ -10,6 +10,10 @@ Use Kafka Bridge when a client application must interact with Kafka through HTTP
 
 This document describes how to create a Kafka Bridge resource, expose the HTTP endpoint, and use common Kafka Bridge API operations.
 
+<Directive type="note" title="Note">
+The examples in this document use `default` as the namespace. In production environments, deploy Kafka Bridge in a dedicated namespace. Replace `default` with the namespace used in your environment.
+</Directive>
+
 ## Prerequisites
 
 Before creating Kafka Bridge, ensure that the following conditions are met:
@@ -18,7 +22,7 @@ Before creating Kafka Bridge, ensure that the following conditions are met:
 2. A Kafka cluster is running and reachable from the Kafka Bridge pods.
 3. Kafka topics used by HTTP clients are created or can be created according to your Kafka cluster policy.
 4. Kafka users, ACLs, and TLS certificates are prepared if the target Kafka cluster enables authentication or TLS.
-5. The network exposure method for the Kafka Bridge HTTP API is defined, such as internal `ClusterIP` access or external `NodePort` access.
+5. The network exposure method for the Kafka Bridge HTTP API is defined, such as internal `ClusterIP` access, external `NodePort` access, or OpenShift `Route`.
 
 ## Create a Kafka Bridge
 
@@ -45,6 +49,10 @@ spec:
 EOF
 ```
 
+<Directive type="warning" title="Consumer Affinity">
+Kafka Bridge stores consumer instances in memory. If you run multiple Kafka Bridge replicas, all requests for the same consumer instance must be routed to the same bridge pod. Use session affinity or another stable routing strategy. If the bridge pod restarts, the consumer instance must be recreated. Default to `replicas: 1` unless your routing layer guarantees consumer affinity.
+</Directive>
+
 ## Create a Kafka Bridge with TLS and SCRAM
 
 If the Kafka cluster requires TLS and SCRAM-SHA-512 authentication, configure `tls` and `authentication` in the `KafkaBridge` resource.
@@ -69,6 +77,119 @@ spec:
       password: password
   http:
     port: 8080
+```
+
+## Configure Consumer and Producer Defaults
+
+Use `spec.consumer` and `spec.producer` to set default consumer and producer configurations for all requests handled by the Kafka Bridge.
+
+```yaml
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaBridge
+metadata:
+  name: my-bridge
+spec:
+  replicas: 1
+  bootstrapServers: my-cluster-kafka-bootstrap:9092
+  http:
+    port: 8080
+  consumer:
+    config:
+      auto.offset.reset: earliest
+  producer:
+    config:
+      delivery.timeout.ms: 300000
+      acks: all
+      linger.ms: 10
+```
+
+These settings apply as defaults for all consumers and producers created through the Bridge API. Individual API requests can override some values where the API supports it.
+
+## Configure Logging
+
+Use `spec.logging` to configure log levels for Kafka Bridge.
+
+Inline logging:
+
+```yaml
+spec:
+  logging:
+    type: inline
+    loggers:
+      logger.bridge.level: INFO
+      logger.healthy.level: WARN
+```
+
+External logging using a ConfigMap:
+
+```yaml
+spec:
+  logging:
+    type: external
+    valueFrom:
+      configMapKeyRef:
+        name: my-bridge-logging
+        key: log4j2.properties
+```
+
+## Configure Metrics
+
+Enable Prometheus metrics collection using `spec.metricsConfig`.
+
+```yaml
+spec:
+  metricsConfig:
+    type: jmxPrometheusExporter
+    valueFrom:
+      configMapKeyRef:
+        name: my-bridge-metrics
+        key: metrics-config.yml
+```
+
+Create the metrics ConfigMap with JMX exporter rules before applying the `KafkaBridge` resource. After metrics are enabled, configure a Prometheus `ServiceMonitor` or `PodMonitor` to scrape the metrics endpoint.
+
+## Configure Distributed Tracing
+
+Enable OpenTelemetry distributed tracing to track messages through Kafka Bridge.
+
+```yaml
+spec:
+  tracing:
+    type: opentelemetry
+  template:
+    bridgeContainer:
+      env:
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: http://otel-collector.observability.svc:4317
+        - name: OTEL_SERVICE_NAME
+          value: my-bridge
+```
+
+## Configure JVM Options
+
+Tune JVM memory allocation for Kafka Bridge pods using `spec.jvmOptions`.
+
+```yaml
+spec:
+  jvmOptions:
+    -Xms: 256m
+    -Xmx: 512m
+```
+
+Set `-Xms` and `-Xmx` according to the `spec.resources` memory values. Leave enough memory for non-heap usage.
+
+## Configure Health Checks
+
+Customize liveness and readiness probe settings if the default values do not match your environment.
+
+```yaml
+spec:
+  livenessProbe:
+    initialDelaySeconds: 30
+    timeoutSeconds: 5
+  readinessProbe:
+    initialDelaySeconds: 30
+    timeoutSeconds: 5
 ```
 
 ## Verify Kafka Bridge
@@ -97,10 +218,6 @@ Check the API endpoint:
 ```bash
 curl http://localhost:8080/
 ```
-
-<Directive type="warning" title="Consumer Affinity">
-Kafka Bridge stores consumer instances in memory. If you run multiple Kafka Bridge replicas, all requests for the same consumer instance must be routed to the same bridge pod. Use session affinity or another stable routing strategy. If the bridge pod restarts, the consumer instance must be recreated.
-</Directive>
 
 ## Use the Kafka Bridge API
 
@@ -193,6 +310,20 @@ curl -X DELETE http://localhost:8080/consumers/my-group/instances/my-consumer
 Always delete unused consumer instances. Consumer instances that are not deleted remain allocated until they expire.
 </Directive>
 
+### Create a Topic
+
+Use the admin API to create a topic through the Kafka Bridge.
+
+```bash
+curl -X POST http://localhost:8080/admin/topics \
+  -H 'content-type: application/json' \
+  -d '{
+    "topic_name": "my-new-topic",
+    "partitions_count": 3,
+    "replication_factor": 3
+  }'
+```
+
 ### Common Content Types
 
 | Content Type | Usage |
@@ -200,10 +331,13 @@ Always delete unused consumer instances. Consumer instances that are not deleted
 | `application/vnd.kafka.v2+json` | Consumer creation, subscription, and general API requests. |
 | `application/vnd.kafka.json.v2+json` | Producing or consuming JSON records. |
 | `application/vnd.kafka.binary.v2+json` | Producing or consuming Base64 encoded binary records. |
+| `application/json` | Admin API requests such as topic creation. |
 
 ## Expose Kafka Bridge by Service
 
-For internal testing, port forwarding is usually enough. For application access, you can expose Kafka Bridge through a Kubernetes `Service`.
+For internal testing, port forwarding is usually enough. For application access, you can expose Kafka Bridge through a Kubernetes `Service`, OpenShift `Route`, or `Ingress`.
+
+### ClusterIP
 
 Use `ClusterIP` when client applications run inside the cluster.
 
@@ -221,6 +355,8 @@ spec:
       port: 8080
       targetPort: 8080
 ```
+
+### NodePort
 
 Use `NodePort` when external clients need direct access through node addresses.
 
@@ -240,10 +376,59 @@ spec:
       nodePort: 30080
 ```
 
-After the Service is created, configure clients to use the internal service DNS name or the node IP and `NodePort` as the Kafka Bridge HTTP endpoint.
+### OpenShift Route
+
+On OpenShift, use a `Route` to expose Kafka Bridge externally with TLS termination.
+
+```yaml
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: my-bridge-route
+spec:
+  to:
+    kind: Service
+    name: my-bridge-bridge-service
+  port:
+    targetPort: rest-api
+  tls:
+    termination: edge
+```
+
+### Ingress
+
+On Kubernetes clusters without OpenShift, use an `Ingress` resource.
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: my-bridge-ingress
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  rules:
+    - host: kafka-bridge.example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: my-bridge-bridge-service
+                port:
+                  number: 8080
+```
+
+After the Service, Route, or Ingress is created, configure clients to use the corresponding endpoint as the Kafka Bridge HTTP URL.
 
 <Directive type="warning" title="Security">
-Do not expose Kafka Bridge without authentication, authorization, and network access control. Kafka Bridge provides HTTP access to Kafka operations and should only be reachable by trusted clients.
+Do not expose Kafka Bridge without authentication, authorization, and network access control. Kafka Bridge provides HTTP access to Kafka operations and should only be reachable by trusted clients. Consider the following measures:
+
+- Use `NetworkPolicy` resources to restrict which pods or namespaces can reach the Kafka Bridge service.
+- On OpenShift, use OAuth Proxy as a sidecar or use the Route TLS termination with client certificate authentication.
+- Place an API gateway or reverse proxy in front of the Kafka Bridge to enforce authentication and rate limiting.
+- Use Kafka ACLs to limit which topics the bridge user can read from or write to.
 </Directive>
 
 ## Key Configuration Parameters
@@ -253,12 +438,19 @@ Do not expose Kafka Bridge without authentication, authorization, and network ac
 | `spec.replicas` | Number of Kafka Bridge pods. Use `1` unless your routing layer keeps requests for the same consumer instance on the same bridge pod. |
 | `spec.bootstrapServers` | Kafka bootstrap server used by Kafka Bridge. |
 | `spec.tls` | TLS configuration for encrypted Kafka connections. |
-| `spec.authentication` | Authentication configuration, such as SCRAM-SHA-512 or TLS authentication. |
+| `spec.authentication` | Authentication configuration, such as SCRAM-SHA-512, TLS, or OAuth. |
 | `spec.http.port` | HTTP port exposed by Kafka Bridge. |
 | `spec.http.cors` | Optional CORS configuration for browser-based clients. |
-| `spec.consumer` | Optional default consumer configuration. |
-| `spec.producer` | Optional default producer configuration. |
+| `spec.consumer` | Default consumer configuration applied to all consumers created through the Bridge API. |
+| `spec.producer` | Default producer configuration applied to all producers created through the Bridge API. |
 | `spec.resources` | CPU and memory resource requests and limits. |
+| `spec.logging` | Logging configuration. Supports inline loggers or an external ConfigMap reference. |
+| `spec.metricsConfig` | Prometheus JMX exporter configuration for metrics collection. |
+| `spec.tracing` | Distributed tracing configuration. Supports OpenTelemetry. |
+| `spec.jvmOptions` | JVM memory and GC options for Kafka Bridge pods. |
+| `spec.livenessProbe` | Liveness probe configuration. |
+| `spec.readinessProbe` | Readiness probe configuration. |
+| `spec.template` | Template for customizing pod labels, annotations, affinity rules, and container environment variables. |
 
 ## Configure CORS
 
@@ -289,11 +481,14 @@ spec:
 
 1. Use Kafka Bridge for HTTP integration and lightweight clients, not as the default path for high-throughput Kafka applications.
 2. Use native Kafka clients for services that require maximum throughput, partition-level tuning, or advanced Kafka client features.
-3. Restrict network access to Kafka Bridge and apply platform-level authentication and rate limiting.
+3. Restrict network access to Kafka Bridge using `NetworkPolicy` and apply platform-level authentication and rate limiting.
 4. Use Kafka ACLs to limit which topics the bridge user can read from or write to.
-5. Monitor HTTP request latency, error rate, pod restarts, and Kafka authentication failures.
-6. Default to a single Kafka Bridge replica for mixed producer and consumer workloads unless your routing layer guarantees consumer affinity.
-7. If you scale Kafka Bridge for consumer traffic, ensure requests for each consumer instance stay pinned to the same bridge pod.
+5. Enable Prometheus metrics and configure dashboards to monitor HTTP request latency, error rate, pod restarts, and Kafka authentication failures.
+6. Configure logging at an appropriate level. Use `WARN` or `INFO` in production and `DEBUG` only for troubleshooting.
+7. Default to a single Kafka Bridge replica for mixed producer and consumer workloads unless your routing layer guarantees consumer affinity.
+8. If you scale Kafka Bridge for consumer traffic, ensure requests for each consumer instance stay pinned to the same bridge pod.
+9. Set `spec.consumer` and `spec.producer` defaults to enforce consistent behavior across all Bridge API requests.
+10. On OpenShift, prefer `Route` with TLS termination over `NodePort` for external access.
 
 ## Troubleshooting
 
@@ -305,3 +500,5 @@ spec:
 | Consume requests return no records | Verify the consumer subscription, offsets, topic data, and `auto.offset.reset` setting. |
 | Consumer requests fail after scaling or load balancing | Verify session affinity or other sticky routing for the same consumer instance. |
 | Browser clients fail | Verify CORS settings and Service exposure or TLS configuration. |
+| Metrics not available | Verify the metrics ConfigMap exists and `spec.metricsConfig` references the correct key. |
+| Tracing spans not visible | Verify `spec.tracing` is set and the OpenTelemetry collector is reachable. |

--- a/docs/en/how_to/37-kafka-bridge.mdx
+++ b/docs/en/how_to/37-kafka-bridge.mdx
@@ -1,0 +1,307 @@
+---
+weight: 37
+---
+
+# Using Kafka Bridge
+
+Kafka Bridge is a Strimzi component that provides HTTP access to Kafka. Applications can use the Kafka Bridge REST API to send messages to Kafka topics and consume messages from Kafka topics without using native Kafka client libraries.
+
+Use Kafka Bridge when a client application must interact with Kafka through HTTP. For long-running data integration with source and sink connectors, use Kafka Connect instead.
+
+This document describes how to create a Kafka Bridge resource, expose the HTTP endpoint, and use common Kafka Bridge API operations.
+
+## Prerequisites
+
+Before creating Kafka Bridge, ensure that the following conditions are met:
+
+1. The Strimzi operator is installed and watching the namespace where Kafka Bridge will be created.
+2. A Kafka cluster is running and reachable from the Kafka Bridge pods.
+3. Kafka topics used by HTTP clients are created or can be created according to your Kafka cluster policy.
+4. Kafka users, ACLs, and TLS certificates are prepared if the target Kafka cluster enables authentication or TLS.
+5. The network exposure method for the Kafka Bridge HTTP API is defined, such as internal `ClusterIP` access or external `NodePort` access.
+
+## Create a Kafka Bridge
+
+The following example creates a Kafka Bridge named `my-bridge` and connects it to a Kafka cluster named `my-cluster` through the internal plain bootstrap service.
+
+```bash
+cat << EOF | kubectl -n default apply -f -
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaBridge
+metadata:
+  name: my-bridge
+spec:
+  replicas: 1
+  bootstrapServers: my-cluster-kafka-bootstrap:9092
+  http:
+    port: 8080
+  resources:
+    requests:
+      cpu: 500m
+      memory: 512Mi
+    limits:
+      cpu: 1
+      memory: 1Gi
+EOF
+```
+
+## Create a Kafka Bridge with TLS and SCRAM
+
+If the Kafka cluster requires TLS and SCRAM-SHA-512 authentication, configure `tls` and `authentication` in the `KafkaBridge` resource.
+
+```yaml
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaBridge
+metadata:
+  name: my-bridge
+spec:
+  replicas: 1
+  bootstrapServers: my-cluster-kafka-bootstrap:9093
+  tls:
+    trustedCertificates:
+      - secretName: my-cluster-cluster-ca-cert
+        certificate: ca.crt
+  authentication:
+    type: scram-sha-512
+    username: my-bridge-user
+    passwordSecret:
+      secretName: my-bridge-user
+      password: password
+  http:
+    port: 8080
+```
+
+## Verify Kafka Bridge
+
+Check the Kafka Bridge status:
+
+```bash
+kubectl -n default get kafkabridge my-bridge
+kubectl -n default describe kafkabridge my-bridge
+```
+
+Check bridge pods:
+
+```bash
+kubectl -n default get pods -l strimzi.io/name=my-bridge-bridge
+```
+
+Forward the Kafka Bridge service for local testing:
+
+```bash
+kubectl -n default port-forward service/my-bridge-bridge-service 8080:8080
+```
+
+Check the API endpoint:
+
+```bash
+curl http://localhost:8080/
+```
+
+<Directive type="warning" title="Consumer Affinity">
+Kafka Bridge stores consumer instances in memory. If you run multiple Kafka Bridge replicas, all requests for the same consumer instance must be routed to the same bridge pod. Use session affinity or another stable routing strategy. If the bridge pod restarts, the consumer instance must be recreated.
+</Directive>
+
+## Use the Kafka Bridge API
+
+The examples below use `http://localhost:8080` as the bridge endpoint.
+
+### Send JSON Records
+
+Use `application/vnd.kafka.json.v2+json` for JSON records.
+
+```bash
+curl -X POST http://localhost:8080/topics/my-topic \
+  -H 'content-type: application/vnd.kafka.json.v2+json' \
+  -d '{
+    "records": [
+      {"key": "order-1", "value": {"id": 1, "status": "created"}},
+      {"key": "order-2", "value": {"id": 2, "status": "created"}}
+    ]
+  }'
+```
+
+### Send Binary Records
+
+Use `application/vnd.kafka.binary.v2+json` for binary records. Keys and values must be Base64 encoded.
+
+```bash
+curl -X POST http://localhost:8080/topics/my-topic \
+  -H 'content-type: application/vnd.kafka.binary.v2+json' \
+  -d '{
+    "records": [
+      {"key": "dXNlci0x", "value": "aGVsbG8="}
+    ]
+  }'
+```
+
+### Create a Consumer
+
+Create a consumer instance under a consumer group.
+
+```bash
+curl -X POST http://localhost:8080/consumers/my-group \
+  -H 'content-type: application/vnd.kafka.v2+json' \
+  -d '{
+    "name": "my-consumer",
+    "format": "json",
+    "auto.offset.reset": "earliest",
+    "enable.auto.commit": false
+  }'
+```
+
+The response contains the consumer instance URL. Use that URL for subsequent subscription, polling, commit, and delete operations.
+
+### Subscribe to Topics
+
+Subscribe the consumer instance to one or more topics.
+
+```bash
+curl -X POST http://localhost:8080/consumers/my-group/instances/my-consumer/subscription \
+  -H 'content-type: application/vnd.kafka.v2+json' \
+  -d '{"topics": ["my-topic"]}'
+```
+
+### Retrieve Records
+
+Poll records from the subscribed topics.
+
+```bash
+curl -X GET http://localhost:8080/consumers/my-group/instances/my-consumer/records \
+  -H 'accept: application/vnd.kafka.json.v2+json'
+```
+
+If the response is empty, verify that the topic contains records and that the consumer offset is correct. The first poll can also return an empty array immediately after subscription while the consumer group assignment is still completing. Wait a few seconds and retry.
+
+### Commit Offsets
+
+If `enable.auto.commit` is `false`, commit offsets after records are processed.
+
+```bash
+curl -X POST http://localhost:8080/consumers/my-group/instances/my-consumer/offsets
+```
+
+### Delete a Consumer
+
+Delete the consumer instance when it is no longer needed.
+
+```bash
+curl -X DELETE http://localhost:8080/consumers/my-group/instances/my-consumer
+```
+
+<Directive type="warning" title="Important">
+Always delete unused consumer instances. Consumer instances that are not deleted remain allocated until they expire.
+</Directive>
+
+### Common Content Types
+
+| Content Type | Usage |
+| :--- | :--- |
+| `application/vnd.kafka.v2+json` | Consumer creation, subscription, and general API requests. |
+| `application/vnd.kafka.json.v2+json` | Producing or consuming JSON records. |
+| `application/vnd.kafka.binary.v2+json` | Producing or consuming Base64 encoded binary records. |
+
+## Expose Kafka Bridge by Service
+
+For internal testing, port forwarding is usually enough. For application access, you can expose Kafka Bridge through a Kubernetes `Service`.
+
+Use `ClusterIP` when client applications run inside the cluster.
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-bridge-access
+spec:
+  type: ClusterIP
+  selector:
+    strimzi.io/name: my-bridge-bridge
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+```
+
+Use `NodePort` when external clients need direct access through node addresses.
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-bridge-nodeport
+spec:
+  type: NodePort
+  selector:
+    strimzi.io/name: my-bridge-bridge
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+      nodePort: 30080
+```
+
+After the Service is created, configure clients to use the internal service DNS name or the node IP and `NodePort` as the Kafka Bridge HTTP endpoint.
+
+<Directive type="warning" title="Security">
+Do not expose Kafka Bridge without authentication, authorization, and network access control. Kafka Bridge provides HTTP access to Kafka operations and should only be reachable by trusted clients.
+</Directive>
+
+## Key Configuration Parameters
+
+| Parameter | Description |
+| :--- | :--- |
+| `spec.replicas` | Number of Kafka Bridge pods. Use `1` unless your routing layer keeps requests for the same consumer instance on the same bridge pod. |
+| `spec.bootstrapServers` | Kafka bootstrap server used by Kafka Bridge. |
+| `spec.tls` | TLS configuration for encrypted Kafka connections. |
+| `spec.authentication` | Authentication configuration, such as SCRAM-SHA-512 or TLS authentication. |
+| `spec.http.port` | HTTP port exposed by Kafka Bridge. |
+| `spec.http.cors` | Optional CORS configuration for browser-based clients. |
+| `spec.consumer` | Optional default consumer configuration. |
+| `spec.producer` | Optional default producer configuration. |
+| `spec.resources` | CPU and memory resource requests and limits. |
+
+## Configure CORS
+
+If browser-based clients need to access Kafka Bridge, configure CORS according to your allowed origins and HTTP methods.
+
+```yaml
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaBridge
+metadata:
+  name: my-bridge
+spec:
+  replicas: 1
+  bootstrapServers: my-cluster-kafka-bootstrap:9092
+  http:
+    port: 8080
+    cors:
+      allowedOrigins:
+        - https://app.example.com
+      allowedMethods:
+        - GET
+        - POST
+        - PUT
+        - DELETE
+        - OPTIONS
+```
+
+## Best Practices
+
+1. Use Kafka Bridge for HTTP integration and lightweight clients, not as the default path for high-throughput Kafka applications.
+2. Use native Kafka clients for services that require maximum throughput, partition-level tuning, or advanced Kafka client features.
+3. Restrict network access to Kafka Bridge and apply platform-level authentication and rate limiting.
+4. Use Kafka ACLs to limit which topics the bridge user can read from or write to.
+5. Monitor HTTP request latency, error rate, pod restarts, and Kafka authentication failures.
+6. Default to a single Kafka Bridge replica for mixed producer and consumer workloads unless your routing layer guarantees consumer affinity.
+7. If you scale Kafka Bridge for consumer traffic, ensure requests for each consumer instance stay pinned to the same bridge pod.
+
+## Troubleshooting
+
+| Symptom | Check |
+| :--- | :--- |
+| `KafkaBridge` is not ready | Check `kubectl describe kafkabridge`, bridge pod logs, and Kafka bootstrap connectivity. |
+| HTTP requests return authentication errors | Verify Kafka `spec.authentication`, referenced Secrets, and Kafka user ACLs. |
+| Produce requests fail | Verify the topic exists, the bridge user has write permission, and the payload content type is correct. |
+| Consume requests return no records | Verify the consumer subscription, offsets, topic data, and `auto.offset.reset` setting. |
+| Consumer requests fail after scaling or load balancing | Verify session affinity or other sticky routing for the same consumer instance. |
+| Browser clients fail | Verify CORS settings and Service exposure or TLS configuration. |


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added comprehensive how-to guide for deploying and managing Strimzi-managed Kafka Connect on Kubernetes, covering cluster setup, plugin management, connector creation, configuration, logging, metrics, tracing, and troubleshooting.
  * Added complete guide for Kafka Bridge deployment, configuration, REST API usage, and operational best practices.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alauda/kafka-docs/pull/24?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->